### PR TITLE
Adiciona uma implementação do Crivo de Eratóstenes em Haskell

### DIFF
--- a/algoritmos/crivo_eratostenes/CrivoErastotenes.hs
+++ b/algoritmos/crivo_eratostenes/CrivoErastotenes.hs
@@ -1,0 +1,8 @@
+-- Retorna os primos de uma lista.
+-- Como usar:
+-- crivoEratostenes [2..10000] para os primos entre 2 e 10000
+-- crivoEratorstenes [2..] para todos os primos que seu computador aguentar
+
+crivoEratostenes :: [Int] -> [Int]
+crivoEratostenes [] = []
+crivoEratostenes (x:xs) = x : crivoEratostenes (filter (\y -> y `mod` x /= 0) xs)


### PR DESCRIPTION
Olá de novo :octocat: 

Um algoritmo que gosto muito de usar pra demonstrar avaliação preguiçosa do Haskell é o Crivo de Eratóstenes, que calcula todos os primos. Funciona basicamente filtrando todos os primos de uma lista infinita, gerando uma lista infinita de números primos.

![Sieve_of_Eratosthenes_animation](https://user-images.githubusercontent.com/18356186/67991451-06805880-fc18-11e9-928d-c608458e7dab.gif)

Para cada número da lista, apagamos todos os números divisíveis por ele que vem depois. Podemos fazer isso já que Haskell é preguiçoso, e só vai calcular o próximo elemento da lista quando for hora de printar ele na tela :stuck_out_tongue: 